### PR TITLE
feat jdk error

### DIFF
--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -61,15 +61,17 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
-
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -83,6 +83,16 @@ android {
   }
 }
 
+kotlin {
+  jvmToolchain(11)
+}
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}
+
 repositories {
   mavenCentral()
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karte-expo-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Config plugin for karte-react-native package",
   "main": "build/withKarte.js",
   "types": "build/withKarte.d.ts",


### PR DESCRIPTION
# 方針
gradle8系以上、jdk17が指定されているときに`Error: task (current target is 17) and 'compileReleaseKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.`とのエラーで落ちたのでexpoのmigrationガイドをもとに修正しました


- https://github.com/expo/fyi/blob/main/expo-modules-gradle8-migration.md#error-task-current-target-is-17-and-compilereleasekotlin-task-current-target-is-11-jvm-target-compatibility-should-be-set-to-the-same-java-version

